### PR TITLE
Update Ruby package linker flags

### DIFF
--- a/ext/ruby-protocol-quic-lock.yml
+++ b/ext/ruby-protocol-quic-lock.yml
@@ -15,7 +15,7 @@ protocol-quic:
   :commit: 4fa6aaa1b2dcb8f493d4c58535c0417e94095f27
   :branch: main
 ruby:
-  :commit: 3421a91f32deb5700329b1d30bb5b6feaa39cdcc
+  :commit: 685cdd5a421dae7749f368d08add9aa9709ad043
   :branch: main
 generate-template:
   :commit: ad0dcfb6da64cc0508b71916b30e1050c82ecea7


### PR DESCRIPTION
## Summary

- update the Teapot lockfile to use kurocha/ruby 685cdd5
- the upstream ruby package now includes both DLDFLAGS and EXTDLDFLAGS when linking Ruby extension bundles
- this restores -Wl,-undefined,dynamic_lookup on macOS while keeping the bundle_loader from Ruby config

## Testing

- cd ext && env BUNDLE_IGNORE_CONFIG=1 GEM_HOME="$PWD/../.bundle/gems" GEM_PATH="$PWD/../.bundle/gems" bundle exec teapot Ruby/Protocol/QUIC
- env BUNDLE_IGNORE_CONFIG=1 GEM_HOME="$PWD/.bundle/gems" GEM_PATH="$PWD/.bundle/gems" bundle exec sus
- env BUNDLE_IGNORE_CONFIG=1 GEM_HOME="$PWD/.bundle/gems" GEM_PATH="$PWD/.bundle/gems" ruby test.rb